### PR TITLE
Add internationalization for ES, EN, CA

### DIFF
--- a/custom_components/chj_saih/manifest.json
+++ b/custom_components/chj_saih/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "chj_saih",
-  "name": "CHJ SAIH",
+  "name": "%integration_name%",
   "documentation": "https://github.com/carlos-48/ha-chj-saih",
   "issue_tracker": "https://github.com/carlos-48/ha-chj-saih/issues",
   "codeowners": ["@carlos-48"],

--- a/custom_components/chj_saih/translations/.gitkeep
+++ b/custom_components/chj_saih/translations/.gitkeep
@@ -1,0 +1,1 @@
+# This is a dummy file to ensure the directory is tracked by git.

--- a/custom_components/chj_saih/translations/ca.json
+++ b/custom_components/chj_saih/translations/ca.json
@@ -1,0 +1,29 @@
+{
+  "integration_name": "CHJ SAIH",
+  "config": {
+    "title": "CHJ SAIH",
+    "step": {
+      "user": {
+        "title": "Configuració de CHJ SAIH",
+        "description": "Seguiu aquests passos per configurar la integració CHJ SAIH.",
+        "data": {
+          "scan_interval": "Interval d'actualització (minuts)"
+        }
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Ja existeix una instància de CHJ SAIH configurada. Només es permet una instància."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opcions de CHJ SAIH",
+        "description": "Modifiqueu l'interval d'actualització per a la integració CHJ SAIH.",
+        "data": {
+          "scan_interval": "Interval d'actualització (minuts)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/chj_saih/translations/en.json
+++ b/custom_components/chj_saih/translations/en.json
@@ -1,0 +1,29 @@
+{
+  "integration_name": "CHJ SAIH",
+  "config": {
+    "title": "CHJ SAIH",
+    "step": {
+      "user": {
+        "title": "CHJ SAIH Configuration",
+        "description": "Follow these steps to set up the CHJ SAIH integration.",
+        "data": {
+          "scan_interval": "Update interval (minutes)"
+        }
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "An instance of CHJ SAIH is already configured. Only one instance is allowed."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "CHJ SAIH Options",
+        "description": "Modify the update interval for the CHJ SAIH integration.",
+        "data": {
+          "scan_interval": "Update interval (minutes)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/chj_saih/translations/es.json
+++ b/custom_components/chj_saih/translations/es.json
@@ -1,0 +1,29 @@
+{
+  "integration_name": "CHJ SAIH",
+  "config": {
+    "title": "CHJ SAIH",
+    "step": {
+      "user": {
+        "title": "Configuración de CHJ SAIH",
+        "description": "Siga estos pasos para configurar la integración CHJ SAIH.",
+        "data": {
+          "scan_interval": "Intervalo de actualización (minutos)"
+        }
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Ya existe una instancia de CHJ SAIH configurada. Solo se permite una instancia."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de CHJ SAIH",
+        "description": "Modifique el intervalo de actualización para la integración CHJ SAIH.",
+        "data": {
+          "scan_interval": "Intervalo de actualización (minutos)"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- I created a `translations` directory and added `en.json`, `es.json`, and `ca.json`.
- I populated translation files for the configuration flow (titles, descriptions, field labels, abort reasons) and options flow.
- I updated `manifest.json` to use a translatable integration name (`%integration_name%`) and added this key to all translation files.
- I verified `config_flow.py` uses standard HA patterns for automatic translation.
- I validated the JSON structure of all translation files.

This change allows the integration's setup and options to be displayed in English, Spanish, or Catalan/Valencian based on your Home Assistant language settings.